### PR TITLE
Fix too many open files and when using OpenAI client.

### DIFF
--- a/completionist/llm_api.py
+++ b/completionist/llm_api.py
@@ -5,6 +5,7 @@ from typing import Optional, Union
 from pydantic import BaseModel
 from openai import OpenAI as OpenAIClient
 import outlines
+import httpx
 
 
 def process_json(raw_response: str):
@@ -71,7 +72,13 @@ def get_completion(
 
     try:
         # For outlines, the client needs the base URL, not the full endpoint
-        client = OpenAIClient(base_url=api_url, api_key=api_token or "dummy")
+        client = OpenAIClient(
+            base_url=api_url,
+            api_key=api_token or "dummy",
+            http_client=httpx.Client(
+                limits=httpx.Limits(max_connections=1000, max_keepalive_connections=100)
+            ),
+        )
 
         if pydantic_schema:
             generator = outlines.models.openai.OpenAI(


### PR DESCRIPTION
Since we introduced OpenAI's client for completions:

```
Error during structured generation for prompt: 'I had a head injury a few years ago and my mind ra...': Traceback (most recent call last):
  File "/Users/ethicalabs/Workspace/completionist/completionist/llm_api.py", line 74, in get_completion
  File "/Users/ethicalabs/Workspace/completionist/.venv/lib/python3.11/site-packages/openai/_client.py", line 154, in __init__
  File "/Users/ethicalabs/Workspace/completionist/.venv/lib/python3.11/site-packages/openai/_base_client.py", line 861, in __init__
  File "/Users/ethicalabs/Workspace/completionist/.venv/lib/python3.11/site-packages/openai/_base_client.py", line 791, in __init__
  File "/Users/ethicalabs/Workspace/completionist/.venv/lib/python3.11/site-packages/httpx/_client.py", line 688, in __init__
  File "/Users/ethicalabs/Workspace/completionist/.venv/lib/python3.11/site-packages/httpx/_client.py", line 731, in _init_transport
  File "/Users/ethicalabs/Workspace/completionist/.venv/lib/python3.11/site-packages/httpx/_transports/default.py", line 153, in __init__
  File "/Users/ethicalabs/Workspace/completionist/.venv/lib/python3.11/site-packages/httpx/_config.py", line 40, in create_ssl_context
  File "/Users/ethicalabs/.local/share/uv/python/cpython-3.11.11-macos-aarch64-none/lib/python3.11/ssl.py", line 770, in create_default_context
OSError: [Errno 24] Too many open files
```

https://github.com/openai/openai-python/issues/933
https://github.com/openai/openai-python/issues/874#issuecomment-1824966775
https://github.com/langchain-ai/langchain/issues/16770